### PR TITLE
Support for retrywrites parameter

### DIFF
--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -9,6 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"strconv"
 )
 
 
@@ -21,8 +22,8 @@ type ClientConfig struct {
 	Ssl      bool
 	InsecureSkipVerify bool
 	ReplicaSet string
+	RetryWrites bool
 	Certificate	    string
-
 }
 type DbUser struct {
 	Name     string `json:"name"`
@@ -87,6 +88,9 @@ func (c *ClientConfig) MongoClient() (*mongo.Client, error) {
 
 
 	var arguments = ""
+
+	arguments = addArgs(arguments,"retrywrites="+strconv.FormatBool(c.RetryWrites))
+
 	if c.Ssl {
 		arguments = addArgs(arguments,"ssl=true")
 	}
@@ -156,6 +160,9 @@ func buildHttpClientFromCertPath(ca , cert , key []byte, config *ClientConfig) (
 		tlsConfig.RootCAs = caPool
 	}
 	var arguments = ""
+
+	arguments = addArgs(arguments,"retrywrites="+strconv.FormatBool(config.RetryWrites))
+
 	if config.Ssl {
 		arguments = addArgs(arguments,"ssl=true")
 	}
@@ -194,6 +201,9 @@ func buildHTTPClientFromBytes(caPEMCert, certPEMBlock, keyPEMBlock []byte, confi
 		tlsConfig.InsecureSkipVerify = true
 	}
 	var arguments = ""
+
+	arguments = addArgs(arguments,"retrywrites="+strconv.FormatBool(config.RetryWrites))
+
 	if config.Ssl {
 		arguments = addArgs(arguments,"ssl=true")
 	}

--- a/mongodb/provider.go
+++ b/mongodb/provider.go
@@ -65,6 +65,12 @@ func Provider() *schema.Provider {
 				Default:     false,
 				Description: "ssl activation",
 			},
+			"retrywrites": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Retryable Writes",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"mongodb_db_user": resourceDatabaseUser(),
@@ -91,6 +97,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		ReplicaSet:      d.Get("replica_set").(string),
 		Certificate:       d.Get("certificate").(string),
 		InsecureSkipVerify: d.Get("insecure_skip_verify").(bool),
+		RetryWrites: d.Get("retrywrites").(bool),
 	}
 
 	client, err := clientConfig.MongoClient()


### PR DESCRIPTION
We had a issue deleting users from AWS DocumentDB

"Error: Retryable writes are not supported"

Because we don't know if this is something you would want to have default enabled on all databases the config variable is a bool, but if the bool is not set the parameter is not included. This complicates the code a bit.

We can change the parameter into a string instead of a bool to simplify it, or just default it to true on the uri string if that's better.