### PR TITLE
Add SOCKS proxy support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -106,3 +106,6 @@ arguments](https://www.terraform.io/docs/configuration/providers.html) (e.g.
 * `direct   ` - (Optional) `default = false ` determine if a direct connection is needed..
 
 
+## SOCKS5 Proxy Support
+
+The mongodb provider supports connecting via a SOCKS5 proxy. It can be configured by setting the `ALL_PROXY` or `all_proxy` environment variable to a value like `socks5://127.0.0.1:10022`.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.1.0
 	github.com/mitchellh/mapstructure v1.1.2
 	go.mongodb.org/mongo-driver v1.7.0
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 )
 
 require (
@@ -37,7 +38,6 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	github.com/zclconf/go-cty v1.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
-	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/sys v0.0.0-20200523222454-059865788121 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -9,6 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"golang.org/x/net/proxy"
 	"strconv"
 	"time"
 )
@@ -107,6 +108,8 @@ func (c *ClientConfig) MongoClient() (*mongo.Client, error) {
 
 	var uri = "mongodb://" + c.Host + ":" + c.Port + arguments
 
+	dialer := proxy.FromEnvironment().(options.ContextDialer)
+
 	/*
 		@Since: v0.0.9
 		verify certificate
@@ -125,14 +128,14 @@ func (c *ClientConfig) MongoClient() (*mongo.Client, error) {
 		}
 		mongoClient, err := mongo.NewClient(options.Client().ApplyURI(uri).SetAuth(options.Credential{
 			AuthSource: c.DB, Username: c.Username, Password: c.Password,
-		}).SetTLSConfig(tlsConfig))
+		}).SetTLSConfig(tlsConfig).SetDialer(dialer))
 
 		return mongoClient, err
 	}
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(uri).SetAuth(options.Credential{
 		AuthSource: c.DB, Username: c.Username, Password: c.Password,
-	}))
+	}).SetDialer(dialer))
 	return client, err
 }
 


### PR DESCRIPTION
It allows you to proxy the requests to the MongoDB server through a SOCKS proxy, in case the MongoDB server cannot be reached directly.
